### PR TITLE
I want to exclude from error report words from specified languages

### DIFF
--- a/src/main/java/org/spellchecker/ArgumentParser.java
+++ b/src/main/java/org/spellchecker/ArgumentParser.java
@@ -20,6 +20,7 @@ public class ArgumentParser {
         var directory = System.getenv("ASCIIDOC_PATH");
         var adocFile = System.getenv("ASCIIDOC_FILE");
         var langCode = Optional.ofNullable(System.getenv("ASCIIDOC_LANG")).orElse("en-US");
+        var additionalLangCodes = Arrays.stream(Optional.ofNullable(System.getenv("ASCIIDOC_ADDITIONAL_LANGS")).orElse("").split(" ")).filter(x -> !x.isEmpty()).toList();
         var wordsIgnoredFile = System.getenv("ASCIIDOC_WORDS_IGNORED");
         var sarifFile = System.getenv("ASCIIDOC_SARIF_FILE");
 
@@ -29,6 +30,11 @@ public class ArgumentParser {
                 .choices(Languages.get().stream().map(Language::getShortCodeWithCountryAndVariant).collect(Collectors.toList()))
                 .setDefault(langCode)
                 .help("specify the language to use (default: en-US)");
+        parser.addArgument("--additional-languages")
+                .nargs("*")
+                .choices(Languages.get().stream().map(Language::getShortCodeWithCountryAndVariant).collect(Collectors.toList()))
+                .setDefault(additionalLangCodes)
+                .help("additional languages to spellcheck words that fail spellchecking in the primary language");
         parser.addArgument("-d", "--directory")
                 .setDefault(directory)
                 .help("specify the base directory containing the Asciidoc files");
@@ -55,6 +61,7 @@ public class ArgumentParser {
         directory = ns.getString("directory");
         adocFile = ns.getString("file");
         langCode = ns.getString("language");
+        additionalLangCodes = ns.getList("additional_languages");
         wordsIgnoredFile = ns.getString("words_ignored");
         sarifFile = ns.getString("sarif_path");
 
@@ -86,6 +93,7 @@ public class ArgumentParser {
                 .adocFile(adocFile)
                 .directory(directory)
                 .langCode(langCode)
+                .additionalLangCodes(additionalLangCodes)
                 .sarifFile(sarifFile)
                 .wordsToIgnore(wordsToIgnore)
                 .build();

--- a/src/main/java/org/spellchecker/ArgumentParser.java
+++ b/src/main/java/org/spellchecker/ArgumentParser.java
@@ -20,7 +20,7 @@ public class ArgumentParser {
         var directory = System.getenv("ASCIIDOC_PATH");
         var adocFile = System.getenv("ASCIIDOC_FILE");
         var langCode = Optional.ofNullable(System.getenv("ASCIIDOC_LANG")).orElse("en-US");
-        var additionalLangCodes = Arrays.stream(Optional.ofNullable(System.getenv("ASCIIDOC_ADDITIONAL_LANGS")).orElse("").split(" ")).filter(x -> !x.isEmpty()).toList();
+        var additionalLangCodes = Optional.ofNullable(System.getenv("ASCIIDOC_ADDITIONAL_LANGS")).orElse("");
         var wordsIgnoredFile = System.getenv("ASCIIDOC_WORDS_IGNORED");
         var sarifFile = System.getenv("ASCIIDOC_SARIF_FILE");
 
@@ -31,10 +31,9 @@ public class ArgumentParser {
                 .setDefault(langCode)
                 .help("specify the language to use (default: en-US)");
         parser.addArgument("--additional-languages")
-                .nargs("*")
-                .choices(Languages.get().stream().map(Language::getShortCodeWithCountryAndVariant).collect(Collectors.toList()))
+                .type(String.class)
                 .setDefault(additionalLangCodes)
-                .help("additional languages to spellcheck words that fail spellchecking in the primary language");
+                .help("space-separated list (between double quotes, e.g. \"en-US de\") of additional languages to spellcheck words failing spellchecking in the primary language");
         parser.addArgument("-d", "--directory")
                 .setDefault(directory)
                 .help("specify the base directory containing the Asciidoc files");
@@ -61,7 +60,7 @@ public class ArgumentParser {
         directory = ns.getString("directory");
         adocFile = ns.getString("file");
         langCode = ns.getString("language");
-        additionalLangCodes = ns.getList("additional_languages");
+        additionalLangCodes = ns.getString("additional_languages");
         wordsIgnoredFile = ns.getString("words_ignored");
         sarifFile = ns.getString("sarif_path");
 
@@ -93,7 +92,7 @@ public class ArgumentParser {
                 .adocFile(adocFile)
                 .directory(directory)
                 .langCode(langCode)
-                .additionalLangCodes(additionalLangCodes)
+                .additionalLangCodes(Arrays.stream(additionalLangCodes.split(" ")).toList())
                 .sarifFile(sarifFile)
                 .wordsToIgnore(wordsToIgnore)
                 .build();

--- a/src/main/java/org/spellchecker/AsciidocIssueFinder.java
+++ b/src/main/java/org/spellchecker/AsciidocIssueFinder.java
@@ -10,6 +10,7 @@ import org.asciidoctor.ast.StructuralNode;
 import org.jsoup.nodes.Document;
 import org.languagetool.rules.patterns.PatternRule;
 import org.languagetool.rules.patterns.PatternToken;
+import org.languagetool.rules.spelling.SpellingCheckRule;
 import org.spellchecker.model.*;
 import org.jsoup.Jsoup;
 import org.languagetool.JLanguageTool;
@@ -28,7 +29,7 @@ import java.util.List;
 public class AsciidocIssueFinder {
 
     private final JLanguageTool langTool;
-
+    private final JLanguageTool altLangTool;
     private final Asciidoctor asciidoctor;
 
     private MatchManager matchManager;
@@ -49,6 +50,13 @@ public class AsciidocIssueFinder {
                     langTool.disableRule(rule.getId());
                 }
 
+            }
+        }
+
+        altLangTool = new JLanguageTool(Languages.getLanguageForShortCode("en-US"));
+        for(var rule: altLangTool.getAllActiveRules()) {
+            if(!(rule instanceof SpellingCheckRule)) {
+                altLangTool.disableRule(rule.getId());
             }
         }
 
@@ -103,7 +111,7 @@ public class AsciidocIssueFinder {
                     List<InlineIgnoredRule> inlineIgnoredRules = processSourceMap(subSourceMap);
                     List<RuleMatch> matches = langTool.check(subSourceMap.getText());
                     for (RuleMatch match : matches) {
-                        matchManager.handleMatch(subSourceMap, rulesToIgnore, match, inlineIgnoredRules)
+                        matchManager.handleMatch(subSourceMap, rulesToIgnore, match, inlineIgnoredRules, altLangTool)
                                 .ifPresent(issues::add);
                     }
                 }

--- a/src/main/java/org/spellchecker/AsciidocSpellChecker.java
+++ b/src/main/java/org/spellchecker/AsciidocSpellChecker.java
@@ -11,7 +11,7 @@ public class AsciidocSpellChecker {
         ArgumentParser argumentParser = new ArgumentParser();
         var analysisConfiguration = argumentParser.parse(args);
 
-        AsciidocIssueFinder finder = new AsciidocIssueFinder(analysisConfiguration.getLangCode(), analysisConfiguration.getWordsToIgnore());
+        AsciidocIssueFinder finder = new AsciidocIssueFinder(analysisConfiguration.getLangCode(), analysisConfiguration.getAdditionalLangCodes(), analysisConfiguration.getWordsToIgnore());
         var result = finder.parseAsciidoc(analysisConfiguration.getAdocFile(), analysisConfiguration.getDirectory());
         SarifIssueConverter sarifConverter = new SarifIssueConverter();
         var sarif = sarifConverter.convert(result);

--- a/src/main/java/org/spellchecker/MatchManager.java
+++ b/src/main/java/org/spellchecker/MatchManager.java
@@ -29,7 +29,7 @@ public class MatchManager {
             return Optional.empty();
         }
 
-        // when the RuleMatch to handle is due to a SpellingCheckRule, check if foundText is valid for the alternative language tools
+        // when the RuleMatch to handle is due to a SpellingCheckRule, check if foundText is valid for AT LEAST one of the alternative languages
         if(ruleMatch.getRule() instanceof SpellingCheckRule) {
 
             List<List<RuleMatch>> altLangRuleMatches = new ArrayList<>();
@@ -43,6 +43,7 @@ public class MatchManager {
                 e.printStackTrace();
             }
 
+            // if found text is valid for AT LEAST one of the alternative languages, the corresponding List<RuleMatch> must be empty
             for (var ruleMatches : altLangRuleMatches) {
                 if (ruleMatches.isEmpty()) {
                     return Optional.empty();

--- a/src/main/java/org/spellchecker/model/AnalysisConfiguration.java
+++ b/src/main/java/org/spellchecker/model/AnalysisConfiguration.java
@@ -11,6 +11,7 @@ public class AnalysisConfiguration {
     private String directory;
     private String adocFile;
     private String langCode;
+    private List<String> additionalLangCodes;
     private List<String> wordsToIgnore;
     private String sarifFile;
 }


### PR DESCRIPTION
Would be nice to be able to automatically exclude words in other languages (e.g. English), 
instead of specify each word in a `wordsIgnored.txt` file. 

This new feature is implemented using the following strategy: 

- a list (eventually empty) of additional languages is given as input to the program  
(using the `ASCIIDOC_ADDITIONAL_LANGS` env variable or the cli argument `--additional-languages`
- a list of `JLanguageTool`, one for each additional language 
Only the `SpellingCheckRule`s of each language are kept (we are not interested in checking other kind of rules for the additional languages) 
- every time the the `SpellingCheckRule`s for the primary language fire, the word is checked against the additional languages
  - if that word is valid in at least one of the additional languages, that word is excluded from the final report



